### PR TITLE
BLD: move lightpath to run requirements

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   noarch: python
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install . -vv
 
 requirements:
@@ -23,6 +23,7 @@ requirements:
     - bluesky >=1.6.4
     - happi
     - jsonschema
+    - lightpath >=1.0.0
     - matplotlib-base
     - numpy
     - ophyd >=1.5.1
@@ -36,7 +37,6 @@ requirements:
     - schema
     - scipy
   run_constrained:
-    - lightpath >=1.0.0
     - pmgr >=2.0.2
     - typhos >=2.4.0
 


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

Changes lightpath to be a required package rather than run_constrained
