### PR TITLE
BLD: fix the bad sha256, bump build number

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,11 +7,11 @@ package:
 
 source:
   url: https://github.com/pcdshub/pcdsdevices/archive/v{{ version }}.tar.gz
-  sha256: 7937ddc05665df4e52d60bb39f0f8b1edf0fff7455efd89d156d4de5b43b25d2
+  sha256: caa3dfe32a2b3c60c4f5526f9a7692ae93ac8c950a8b5602741d245f20ddc4a6
 
 build:
   noarch: python
-  number: 1
+  number: 2
   script: {{ PYTHON }} -m pip install . -vv
 
 requirements:


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->
See https://dev.azure.com/conda-forge/feedstock-builds/_build/results?buildId=610859&view=logs&j=656edd35-690f-5c53-9ba3-09c10d0bea97&t=e5c8ab1d-8ff9-5cae-b332-e15ae582ed2d&l=107,
this build did not get built or deployed.

I downloaded the tarball myself and checked what the correct SHA256 sum should be
```
$ sha256sum temp/v7.1.0.tar.gz
caa3dfe32a2b3c60c4f5526f9a7692ae93ac8c950a8b5602741d245f20ddc4a6  temp/v7.1.0.tar.gz
```

In a future release we need to change the tarball source from github to pypi to avoid this issue.

<!--
Please add any other relevant info below:
-->
